### PR TITLE
Add CIDR option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Perform active stealth scans, gather passive OSINT, and receive CVE suggestions 
 - ✅ Codename Generator for Operator Identity
 - ✅ Clean HTML + Markdown Report Generation
 - ✅ Subdomain Resolution Support (Passive Mode)
+- ✅ CIDR Range Scanning
 
 ---
 
@@ -33,6 +34,11 @@ python3 nakulascan.py -t example.com --passive
 ### Scan From List:
 ```bash
 sudo python3 nakulascan.py -T examples/targets.txt --scan fin
+```
+
+### Scan a CIDR Range:
+```bash
+sudo python3 nakulascan.py -c 192.168.1.0/24 --scan fin
 ```
 
 ### Save + Resume a Scan:


### PR DESCRIPTION
## Summary
- allow scanning a CIDR range via `-c/--cidr`
- document CIDR support and example in README

## Testing
- `python3 -m py_compile nakula.py resume_manager.py passive_recon.py report_writer.py cve_suggester.py`
- `python3 nakula.py -c 127.0.0.0/30 --nobanner` *(fails: No module named 'scapy')*

------
https://chatgpt.com/codex/tasks/task_e_684227e6f78c83239f5ebff193aeea0d