### PR TITLE
Fix port filtering logic in ResumeManager

### DIFF
--- a/resume_manager.py
+++ b/resume_manager.py
@@ -34,4 +34,5 @@ class ResumeManager:
             remaining_ports = [p for p in ports if p not in already_scanned]
             if remaining_ports:
                 filtered_targets.append(ip)
+                filtered_ports = remaining_ports
         return filtered_targets, filtered_ports


### PR DESCRIPTION
## Summary
- ensure `filtered_ports` returns remaining ports when resuming scans

## Testing
- `python -m py_compile resume_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68424d7f8f088323972b99e6f9362924