### PR TITLE
Support multi-target reporting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,11 @@ sudo python3 nakulascan.py -T examples/targets.txt --scan fin
 sudo python3 nakulascan.py -c 192.168.1.0/24 --scan fin
 ```
 
+### Per-Host Reports from CIDR Range:
+```bash
+sudo python3 nakulascan.py -c 192.168.1.0/24 --scan fin --per-host
+```
+
 ### Save + Resume a Scan:
 ```bash
 sudo python3 nakulascan.py -t scanme.nmap.org --scan null --save session.json
@@ -65,6 +70,8 @@ sudo python3 nakulascan.py -t 192.168.1.5 --udp
 - `reports/NakulaScan_<target>_<timestamp>.html`
 - `reports/NakulaScan_<target>_<timestamp>.csv`
 - `reports/NakulaScan_<target>_<timestamp>.md`
+- `reports/NakulaScan_summary_<timestamp>.*` for multi-target scans
+- `reports/NakulaScan_<ip>_<timestamp>.*` when using `--per-host`
 
 
 ## 🔍 CVE Matching Logic


### PR DESCRIPTION
## Summary
- add `--per-host` option for per-target reports
- group scan results by host and generate summary or per-host reports
- document new flag and output files

## Testing
- `python3 -m py_compile nakula.py report_writer.py resume_manager.py plugin_loader.py passive_recon.py cve_suggester.py fingerprint_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68426f18fb6083238544c2dbc28f35a7